### PR TITLE
fix: chat bugs

### DIFF
--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -4,6 +4,7 @@
 
 	import Logo from "$lib/components/icons/Logo.svelte";
 	import { switchTheme } from "$lib/switchTheme";
+	import { isAborted } from "$lib/stores/isAborted";
 	import { PUBLIC_APP_NAME, PUBLIC_ORIGIN } from "$env/static/public";
 	import NavConversationItem from "./NavConversationItem.svelte";
 	import type { LayoutData } from "../../routes/$types";
@@ -23,6 +24,9 @@
 	export let user: LayoutData["user"];
 
 	export let loginModalVisible;
+	function handleNuevoChatClick() {
+        isAborted.set(true);
+    }
 </script>
 
 <div class="sticky top-0 flex flex-none items-center justify-between px-3 py-3.5 max-sm:pt-0">
@@ -31,6 +35,7 @@
 	</a>
 	<a
 		href={`${base}/`}
+		on:click={handleNuevoChatClick}
 		class="flex rounded-lg border bg-white px-2 py-0.5 text-center shadow-sm hover:shadow-none dark:border-gray-600 dark:bg-gray-700"
 	>
 		Nuevo Chat

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -24,9 +24,9 @@
 	export let user: LayoutData["user"];
 
 	export let loginModalVisible;
-	function handleNuevoChatClick() {
-        isAborted.set(true);
-    }
+	function handleNewChatClick() {
+		isAborted.set(true);
+        }
 </script>
 
 <div class="sticky top-0 flex flex-none items-center justify-between px-3 py-3.5 max-sm:pt-0">

--- a/src/lib/components/NavMenu.svelte
+++ b/src/lib/components/NavMenu.svelte
@@ -35,7 +35,7 @@
 	</a>
 	<a
 		href={`${base}/`}
-		on:click={handleNuevoChatClick}
+		on:click={handleNewChatClick}
 		class="flex rounded-lg border bg-white px-2 py-0.5 text-center shadow-sm hover:shadow-none dark:border-gray-600 dark:bg-gray-700"
 	>
 		Nuevo Chat

--- a/src/lib/stores/isAborted.ts
+++ b/src/lib/stores/isAborted.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const isAborted = writable<boolean>(false);


### PR DESCRIPTION
This PR fixes two bugs:
1. When creating a new chat, if the current chat is still streaming, both responses will be displayed on the screen, mixing the conversations. To solve that, the `isAborted` variable, which controls the current status of the response, is defined as a writable object from Svelte/store. This allows multiple components to manipulate it. That way, when the `Nuevo Chat` button is pressed, the status of `isAborted` is set to `true`.
2. When the user asks a question, before the response is displayed on the screen, if the conversation is changed, the `loading` sign was visible on the new conversation, even though the question does not belong to that specific chat. To solve that, a new condition was added so that the `pending` variable is set to `false` every time the conversation ID changes.





